### PR TITLE
feat: auto handling worker results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,5 +33,4 @@ All notable changes to zeebe-rs will be documented in this file. The format is b
 
 ## Notes
 
-This version is compatible with Zeebe v5.29.2
-API should be considered unstable until 1.0.0
+This version is compatible with Zeebe v5.29.2. API should be considered unstable until 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,20 @@ All notable changes to zeebe-rs will be documented in this file. The format is b
 
 ### Security
 
-## 0.2.0 - TBD
+## 0.2.0 - 2024-01-28
+
+### Added
+
+- Added new error type `WorkerError<R>`
+- Added support for worker handlers that return `Result<T, WorkerError<R>>`
+  - Any worker handler that returns a `Result` instead of `()` now automatically reports success/failure to Zeebe
+    using `fail_job`, `throw_error` or `complete_job`.
 
 ### Changed
 
 - Refactored worker builder for easier re-use of shared configurations
 - Updated documentation across solution
+- Updated `pizza` example to reflect new worker functionality
 
 ## 0.1.0 - 2024-01-27
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -719,7 +719,7 @@ impl Client {
     ///    .run()
     ///    .await;
     /// ```
-    pub fn worker(&self) -> WorkerBuilder<crate::worker::Initial> {
-        WorkerBuilder::<crate::worker::Initial>::new(self.clone())
+    pub fn worker<Output: Send + 'static>(&self) -> WorkerBuilder<crate::worker::Initial, Output> {
+        WorkerBuilder::<crate::worker::Initial, Output>::new(self.clone())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,4 +54,4 @@ pub use set_variables::{SetVariablesRequest, SetVariablesResponse};
 pub use signal::{BroadcastSignalRequest, BroadcastSignalResponse};
 pub use throw_error::{ThrowErrorRequest, ThrowErrorResponse};
 pub use topology::{TopologyRequest, TopologyResponse};
-pub use worker::SharedState;
+pub use worker::{JobHandler, SharedState, WorkerError, WorkerOutputHandler};

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -90,7 +90,7 @@ impl<T> DerefMut for SharedState<T> {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// async fn my_handler(client: Client, job: ActivatedJob) -> Result<(), WorkerError<()>> {
 ///     // Handle job processing
 ///     Ok(())
@@ -136,7 +136,7 @@ where
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// impl WorkerOutputHandler<()> for () {
 ///     fn handle_result(client: Client, job: ActivatedJob, result: ()) -> Pin<Box<dyn Future<Output = ()> + Send>> {
 ///         Box::pin(async {})

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -129,7 +129,7 @@ where
 ///
 /// # Type Parameters
 ///
-/// * `Output` - The type of output produced by the job handler
+/// * `T` - The type of output produced by the job handler
 ///
 /// # Examples
 ///
@@ -140,11 +140,11 @@ where
 ///     }
 /// }
 /// ```
-pub trait WorkerOutputHandler<Output> {
+pub trait WorkerOutputHandler<T> {
     fn handle_result(
         client: Client,
         job: ActivatedJob,
-        result: Output,
+        result: T,
     ) -> Pin<Box<dyn Future<Output = ()> + Send>>;
 }
 


### PR DESCRIPTION
This implements automatic handling of worker results if the handler returns a Result instead of unit type. The WorkConsumer will automatically report the result to Zeebe based on the Result that was returned from the handler